### PR TITLE
Random fixes from the edit version page

### DIFF
--- a/apps/client/src/pages/editors/inputs.tsx
+++ b/apps/client/src/pages/editors/inputs.tsx
@@ -5,7 +5,7 @@ import { useEffect, useReducer, useRef, useState } from "react"
 import { useErrorEventHandlers } from "./errorEvents"
 
 export const validUrlRegex =
-	/^http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#=_]*)?$/gi
+    /^http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#=_]*)?$/i;
 
 export function getPropertyByPath(obj: any, path: string) {
 	const properties = path.split("/") // Split the path string into an array of property names

--- a/apps/client/src/pages/packs/id/edit.tsx
+++ b/apps/client/src/pages/packs/id/edit.tsx
@@ -241,6 +241,11 @@ export default function PackEdit() {
 		const [dependencies, setDependencies] = useState<PackDependency[]>(
 			version.dependencies
 		)
+		const [id, setId] = useState<string>("")
+		const [versionName, setVersionName] = useState<string>("")
+
+		const [validId, setValidId] = useState(true)
+		const [validVersion, setValidVersion] = useState(true)
 
 		async function getResolvedDep(
 			id: string,
@@ -283,25 +288,25 @@ export default function PackEdit() {
 		return (
 			<div className="dependencies">
 				<IconInput
-					className="inputField"
+					className={"inputField" + (validId ? "" : " invalidInput")}
 					id="new_dep_id"
 					icon={At}
 					placeholder="Dependency ID"
+					value={id}
 					onChange={(v) => {
-						v.currentTarget.parentElement!.classList.remove(
-							"invalidInput"
-						)
+						setValidId(true)
+						setId(v.currentTarget.value)
 					}}
 				/>
 				<IconInput
-					className="inputField"
+					className={"inputField" + (validVersion ? "" : " invalidInput")}
 					id="new_dep_version"
 					icon={ColorPicker}
 					placeholder="Version ID"
+					value={versionName}
 					onChange={(v) => {
-						v.currentTarget.parentElement!.classList.remove(
-							"invalidInput"
-						)
+						setValidVersion(true)
+						setVersionName(v.currentTarget.value)
 					}}
 				/>
 				<div />
@@ -350,14 +355,6 @@ export default function PackEdit() {
 						reverse
 						style={{ backgroundColor: "transparent" }}
 						onClick={async () => {
-							const idElement = document.getElementById(
-								"new_dep_id"
-							)! as HTMLInputElement
-							const id = idElement.value
-							const versionElement = document.getElementById(
-								"new_dep_version"
-							)! as HTMLInputElement
-							const versionName = versionElement.value
 
 							if (id === "" || versionName === "") return
 
@@ -365,9 +362,7 @@ export default function PackEdit() {
 								import.meta.env.VITE_API_SERVER + `/packs/${id}`
 							)
 							if (!packDataResp.ok) {
-								idElement.parentElement!.classList.add(
-									"invalidInput"
-								)
+								setValidId(false)
 								return alert(`Invalid pack id ${id}`)
 							}
 							const packData: PackData = await packDataResp.json()
@@ -377,9 +372,7 @@ export default function PackEdit() {
 								.filter((v) => satisfies(v, versionName))
 
 							if (versions.length === 0) {
-								versionElement.parentElement!.classList.add(
-									"invalidInput"
-								)
+								setValidVersion(false)
 								return alert(
 									`Invalid version ${versionName}, does not exist on pack ${id}`
 								)
@@ -399,8 +392,8 @@ export default function PackEdit() {
 
 							setDependencies([...version.dependencies])
 
-							idElement.value = ""
-							versionElement.value = ""
+							setId("")
+							setVersionName("")
 						}}
 					/>
 				</div>

--- a/packages/formatters/index.ts
+++ b/packages/formatters/index.ts
@@ -122,7 +122,6 @@ export function normalizeRelativeLinks(sourceUrl: string, readme: string) {
 
 	sourceUrl = sourceUrl.split("/").slice(0, -1).join("/") + "/"
 
-	console.log(readme)
 	readme = readme.replaceAll("./", sourceUrl)
 	return readme
 }


### PR DESCRIPTION
Small fixes : 
- edit dependencies work fine now, by using state for dependencie search
- useless console.log when editing
- if the same url was tested twice it would fail (JS is weird, see : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test )